### PR TITLE
Optional Parent Test Cases From FluentBenchmarker

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .library(name: "FluentSQLiteDriver", targets: ["FluentSQLiteDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0-alpha.2"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("optional-parent")),
         .package(url: "https://github.com/vapor/sqlite-kit.git", from: "4.0.0-alpha"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
+++ b/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
@@ -40,6 +40,14 @@ final class FluentSQLiteDriverTests: XCTestCase {
         try self.benchmarker.testEagerLoadParentJSON()
     }
 
+    func testEagerLoadOptionalParent() throws {
+        try self.benchmarker.testEagerLoadOptionalParent()
+    }
+
+    func testEagerLoadOptionalJoinParent() throws {
+        try self.benchmarker.testEagerLoadOptionalJoinParent()
+    }
+
     func testEagerLoadChildrenJSON() throws {
         try self.benchmarker.testEagerLoadChildrenJSON()
     }

--- a/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
+++ b/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
@@ -48,6 +48,10 @@ final class FluentSQLiteDriverTests: XCTestCase {
         try self.benchmarker.testEagerLoadOptionalJoinParent()
     }
 
+    func testEagerLoadOptionalChildren() throws {
+        try self.benchmarker.testEagerLoadOptionalChildren()
+    }
+
     func testEagerLoadChildrenJSON() throws {
         try self.benchmarker.testEagerLoadChildrenJSON()
     }

--- a/Tests/FluentSQLiteDriverTests/XCTestManifests.swift
+++ b/Tests/FluentSQLiteDriverTests/XCTestManifests.swift
@@ -16,6 +16,8 @@ extension FluentSQLiteDriverTests {
         ("testDelete", testDelete),
         ("testEagerLoadChildren", testEagerLoadChildren),
         ("testEagerLoadChildrenJSON", testEagerLoadChildrenJSON),
+        ("testEagerLoadOptionalJoinParent", testEagerLoadOptionalJoinParent),
+        ("testEagerLoadOptionalParent", testEagerLoadOptionalParent),
         ("testEagerLoadParent", testEagerLoadParent),
         ("testEagerLoadParentJoin", testEagerLoadParentJoin),
         ("testEagerLoadParentJSON", testEagerLoadParentJSON),
@@ -25,13 +27,17 @@ extension FluentSQLiteDriverTests {
         ("testMigrator", testMigrator),
         ("testMigratorError", testMigratorError),
         ("testNestedModel", testNestedModel),
+        ("testNewModelDecode", testNewModelDecode),
         ("testNullifyField", testNullifyField),
         ("testRead", testRead),
+        ("testSiblingsAttach", testSiblingsAttach),
+        ("testSiblingsEagerLoad", testSiblingsEagerLoad),
         ("testSoftDelete", testSoftDelete),
         ("testSort", testSort),
         ("testTimestampable", testTimestampable),
         ("testUniqueFields", testUniqueFields),
         ("testUpdate", testUpdate),
+        ("testUUIDModel", testUUIDModel),
     ]
 }
 

--- a/Tests/FluentSQLiteDriverTests/XCTestManifests.swift
+++ b/Tests/FluentSQLiteDriverTests/XCTestManifests.swift
@@ -16,6 +16,7 @@ extension FluentSQLiteDriverTests {
         ("testDelete", testDelete),
         ("testEagerLoadChildren", testEagerLoadChildren),
         ("testEagerLoadChildrenJSON", testEagerLoadChildrenJSON),
+        ("testEagerLoadOptionalChildren", testEagerLoadOptionalChildren),
         ("testEagerLoadOptionalJoinParent", testEagerLoadOptionalJoinParent),
         ("testEagerLoadOptionalParent", testEagerLoadOptionalParent),
         ("testEagerLoadParent", testEagerLoadParent),


### PR DESCRIPTION
Relies on https://github.com/vapor/fluent-kit/pull/63. Make sure to update the package manifest for this repo after merging the FluentKit PR and before merging this one.