### PR TITLE
Make db config more concise

### DIFF
--- a/Sources/FluentSQLiteDriver/Exports.swift
+++ b/Sources/FluentSQLiteDriver/Exports.swift
@@ -1,23 +1,6 @@
 @_exported import FluentKit
 @_exported import SQLiteKit
 
-// TODO: deprecate
-extension Databases {
-    public func sqlite(
-        configuration: SQLiteConfiguration = .init(storage: .memory),
-        maxConnectionsPerEventLoop: Int = 1,
-        as id: DatabaseID = .sqlite
-    ) {
-        self.use(
-            .sqlite(
-                configuration: configuration,
-                maxConnectionsPerEventLoop: maxConnectionsPerEventLoop
-            ),
-            as: id
-        )
-    }
-}
-
 extension DatabaseID {
     public static var sqlite: DatabaseID {
         return .init(string: "sqlite")

--- a/Sources/FluentSQLiteDriver/FluentSQLiteDriver.swift
+++ b/Sources/FluentSQLiteDriver/FluentSQLiteDriver.swift
@@ -1,19 +1,9 @@
 extension DatabaseDriverFactory {
     public static func sqlite(
-        file: String,
+        _ configuration: SQLiteConfiguration = .init(storage: .memory),
         maxConnectionsPerEventLoop: Int = 1
-    ) -> DatabaseDriverFactory {
-        .sqlite(
-            configuration: .init(file: file),
-            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop
-        )
-    }
-    
-    public static func sqlite(
-        configuration: SQLiteConfiguration = .init(storage: .memory),
-        maxConnectionsPerEventLoop: Int = 1
-    ) -> DatabaseDriverFactory {
-        return DatabaseDriverFactory { databases in
+    ) -> Self {
+        return .init { databases in
             let db = SQLiteConnectionSource(
                 configuration: configuration,
                 threadPool: databases.threadPool
@@ -25,6 +15,16 @@ extension DatabaseDriverFactory {
             )
             return _FluentSQLiteDriver(pool: pool)
         }
+    }
+}
+
+extension SQLiteConfiguration {
+    public static func file(_ path: String) -> Self {
+        .init(storage: .file(path: path))
+    }
+
+    public static var memory: Self {
+        .init(storage: .memory)
     }
 }
 

--- a/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
+++ b/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
@@ -160,6 +160,10 @@ final class FluentSQLiteDriverTests: XCTestCase {
         try self.benchmarker.testDuplicatedUniquePropertyName()
     }
 
+    func testRange() throws {
+        try self.benchmarker.testRange()
+    }
+
     var benchmarker: FluentBenchmarker {
         return .init(database: self.database)
     }
@@ -181,10 +185,7 @@ final class FluentSQLiteDriverTests: XCTestCase {
         self.threadPool = .init(numberOfThreads: 2)
         self.threadPool.start()
         self.dbs = Databases(threadPool: self.threadPool, on: self.eventLoopGroup)
-        self.dbs.sqlite(
-            configuration: .init(storage: .memory),
-            maxConnectionsPerEventLoop: 2
-        )
+        self.dbs.use(.sqlite(.memory), as: .sqlite)
     }
 
     override func tearDown() {


### PR DESCRIPTION
New, more concise methods for configuring `.memory` and `.file(_:)`:

```swift
app.databases.use(.sqlite(.memory), as: .sqlite)
app.databases.use(.sqlite(.file("db.sqlite")), as: .sqlite)
```