### PR TITLE
Support dynamic ID keys

### DIFF
--- a/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
+++ b/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
@@ -164,6 +164,10 @@ final class FluentSQLiteDriverTests: XCTestCase {
         try self.benchmarker.testRange()
     }
 
+    func testNonstandardIDKey() throws {
+        try self.benchmarker.testNonstandardIDKey()
+    }
+
     var benchmarker: FluentBenchmarker {
         return .init(database: self.database)
     }


### PR DESCRIPTION
Adds support for dynamic ID keys introduced in https://github.com/vapor/fluent-kit/pull/153 (#44).