### PR TITLE
Fix SQLiteError's DatabaseError conformance

### DIFF
--- a/Sources/FluentSQLiteDriver/SQLiteError+Database.swift
+++ b/Sources/FluentSQLiteDriver/SQLiteError+Database.swift
@@ -1,13 +1,28 @@
 extension SQLiteError: DatabaseError {
     public var isSyntaxError: Bool {
-        return false
+        switch self.reason {
+        case .error:
+            return true
+        default:
+            return false
+        }
     }
 
     public var isConnectionClosed: Bool {
-        return false
+        switch self.reason {
+        case .close, .misuse:
+            return true
+        default:
+            return false
+        }
     }
 
     public var isConstraintFailure: Bool {
-        return false
+        switch self.reason {
+        case .constraint:
+            return true
+        default:
+            return false
+        }
     }
 }


### PR DESCRIPTION
`SQLiteError` now correctly conforms to `DatabaseError` (#50, fixes #49).