### PR TITLE
Clarify ALTER TABLE restrictions

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -3,7 +3,6 @@ on:
    push:
      branches:
        - master
-
 jobs:
   deploy:
     name: api.vapor.codes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,14 @@
-name: Test Matrix
-
+name: test
 on:
   pull_request:
   push:
     branches:
     - master
-
 defaults:
   run:
     shell: bash
-
 jobs:
-
-  Linux:
+  linux:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -34,11 +30,11 @@ jobs:
           - swiftlang/swift:nightly-master-centos8
           - swiftlang/swift:nightly-master-amazonlinux2
         include:
-          - depscmd: 'apt-get -q update && apt-get -q install -y libsqlite3-dev'
+          - depscmd: apt-get -q update && apt-get -q install -y libsqlite3-dev
           - image: swiftlang/swift:nightly-master-centos8
-            depscmd: 'dnf install -y sqlite-devel'
+            depscmd: dnf install -y sqlite-devel
           - image: swiftlang/swift:nightly-master-amazonlinux2
-            depscmd: 'yum install -y sqlite-devel'
+            depscmd: yum install -y sqlite-devel
     container: ${{ matrix.image }}
     steps:
       - name: Install dependencies
@@ -57,13 +53,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
         run: swift test --enable-test-discovery --sanitize=thread
-
   macOS:
     runs-on: macos-latest
     steps:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@1.0
-        with: { 'xcode-version': 'latest' }
+        with:
+          xcode-version: latest
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,3 +64,4 @@ jobs:
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
         run: swift test --enable-test-discovery --sanitize=thread
+

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ database.db
 Package.resolved
 DerivedData
 .swiftpm
-
+Tests/LinuxMain.swift


### PR DESCRIPTION
Adds new checks and error messages to clarify SQLite's `ALTER TABLE` restrictions (#66, fixes #62). 