### PR TITLE
Minimum iOS version is 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "fluent-sqlite-driver",
     platforms: [
-       .macOS(.v10_15)
+        .macOS(.v10_15),
+        .iOS(.v13)
     ],
     products: [
         .library(name: "FluentSQLiteDriver", targets: ["FluentSQLiteDriver"]),


### PR DESCRIPTION
The minimum iOS version supported by this package is now iOS 13 since the SqliteKit dependency requires it.