### PR TITLE
Add configurable connection pool timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-    - master
+      - main
 defaults:
   run:
     shell: bash
@@ -57,11 +57,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@1.0
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
         run: swift test --enable-test-discovery --sanitize=thread
-

--- a/Sources/FluentSQLiteDriver/FluentSQLiteConfiguration.swift
+++ b/Sources/FluentSQLiteDriver/FluentSQLiteConfiguration.swift
@@ -1,13 +1,17 @@
+import NIO
+
 extension DatabaseConfigurationFactory {
     public static func sqlite(
         _ configuration: SQLiteConfiguration = .init(storage: .memory),
-        maxConnectionsPerEventLoop: Int = 1
+        maxConnectionsPerEventLoop: Int = 1,
+        connectionPoolTimeout: NIO.TimeAmount = .seconds(10)
     ) -> Self {
         return .init {
             FluentSQLiteConfiguration(
                 configuration: configuration,
                 maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
-                middleware: []
+                middleware: [],
+                connectionPoolTimeout: connectionPoolTimeout
             )
         }
     }
@@ -17,6 +21,7 @@ struct FluentSQLiteConfiguration: DatabaseConfiguration {
     let configuration: SQLiteConfiguration
     let maxConnectionsPerEventLoop: Int
     var middleware: [AnyModelMiddleware]
+    let connectionPoolTimeout: NIO.TimeAmount
 
     func makeDriver(for databases: Databases) -> DatabaseDriver {
         let db = SQLiteConnectionSource(
@@ -26,6 +31,7 @@ struct FluentSQLiteConfiguration: DatabaseConfiguration {
         let pool = EventLoopGroupConnectionPool(
             source: db,
             maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+            requestTimeout: connectionPoolTimeout,
             on: databases.eventLoopGroup
         )
         return _FluentSQLiteDriver(pool: pool)


### PR DESCRIPTION
Adds option to configure the connection pool timeout (#74)

```swift
databases.use(.sqlite(.memory, connectionPoolTimeout: .minutes(1)), as: .sqlite)
```