### PR TITLE
Don't double-run all of the FluentBenchmark tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,63 +4,49 @@ on:
   push:
     branches:
       - main
-defaults:
-  run:
-    shell: bash
+env:
+  LOG_LEVEL: debug
+  SWIFT_DETERMINISTIC_HASHING: 1
+
 jobs:
-  linux:
-    runs-on: ubuntu-latest
+  linux-all:
     strategy:
       fail-fast: false
       matrix:
-        image:
-          # 5.2 Stable
-          - swift:5.2-xenial
-          - swift:5.2-bionic
-          # 5.2 Unstable
-          - swiftlang/swift:nightly-5.2-xenial
-          - swiftlang/swift:nightly-5.2-bionic
-          # 5.3 Unstable
-          - swiftlang/swift:nightly-5.3-xenial
-          - swiftlang/swift:nightly-5.3-bionic
-          # Master Unsable
-          - swiftlang/swift:nightly-master-xenial
-          - swiftlang/swift:nightly-master-bionic
-          - swiftlang/swift:nightly-master-focal
-          - swiftlang/swift:nightly-master-centos8
-          - swiftlang/swift:nightly-master-amazonlinux2
-        include:
-          - depscmd: apt-get -q update && apt-get -q install -y libsqlite3-dev
-          - image: swiftlang/swift:nightly-master-centos8
-            depscmd: dnf install -y sqlite-devel
-          - image: swiftlang/swift:nightly-master-amazonlinux2
-            depscmd: yum install -y sqlite-devel
-    container: ${{ matrix.image }}
+        swiftver:
+          - swift:5.2
+          - swift:5.3
+          - swift:5.4
+          - swift:5.5
+          - swiftlang/swift:nightly-main
+        swiftos:
+          - focal
+    container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
+    runs-on: ubuntu-latest
     steps:
-      - name: Install dependencies
-        run: ${{ matrix.depscmd }}
-      - name: Update AmazonLinux2's too-old SQLite and compensate for its Postgres
-        if: ${{ endsWith(matrix.image, 'amazonlinux2') }}
-        working-directory: /root
-        # Cribbed from the Fedora RPM, leaves out a lot. System's Tcl is too old to run SQLite's tests.
-        run: |
-          yum install -y file tcl-devel make
-          curl -L 'https://www.sqlite.org/src/tarball/sqlite.tar.gz?r=release' | tar xz && cd sqlite
-          export CFLAGS="-DSQLITE_DISABLE_DIRSYNC=1 -DSQLITE_SECURE_DELETE=1"
-          ./configure --prefix=/usr --libdir=/usr/lib64 --enable-fts3 --enable-all --with-tcl=/usr/lib64
-          make all install
-      - name: Checkout code
+      - name: Install SQLite dependency
+        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
+      - name: Check out package
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
         run: swift test --enable-test-discovery --sanitize=thread
-  macOS:
-    runs-on: macos-latest
+    
+  macos-all:
+    strategy:
+      fail-fast: false
+      matrix:
+        xcode:
+          - latest
+          - latest-stable
+    runs-on: macos-11
     steps:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest
-      - name: Checkout code
+        with: 
+          xcode-version: ${{ matrix.xcode }}
+      - name: Check out package
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
+        run: |
+          swift test --sanitize=thread -Xlinker -rpath \
+                -Xlinker $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx

--- a/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
+++ b/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
@@ -5,7 +5,7 @@ import Logging
 import NIO
 
 final class FluentSQLiteDriverTests: XCTestCase {
-    func testAll() throws { try self.benchmarker.testAll() }
+    //func testAll() throws { try self.benchmarker.testAll() }
     func testAggregate() throws { try self.benchmarker.testAggregate() }
     func testArray() throws { try self.benchmarker.testArray() }
     func testBatch() throws { try self.benchmarker.testBatch() }
@@ -32,6 +32,7 @@ final class FluentSQLiteDriverTests: XCTestCase {
     func testSiblings() throws { try self.benchmarker.testSiblings() }
     func testSoftDelete() throws { try self.benchmarker.testSoftDelete() }
     func testSort() throws { try self.benchmarker.testSort() }
+    func testSQL() throws { try self.benchmarker.testSQL() }
     func testTimestamp() throws { try self.benchmarker.testTimestamp() }
     func testTransaction() throws { try self.benchmarker.testTransaction() }
     func testUnique() throws { try self.benchmarker.testUnique() }


### PR DESCRIPTION
Yes, it avoids missing newly added top-level categories, but it wastes a _LOT_ of test runner time. The FluentBenchmark suite needs a better solution for this issue anyhow.