### PR TITLE
Explicitly handle a custom ID key set to the empty string

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         swiftver:
-          - swift:5.2
-          - swift:5.3
           - swift:5.4
           - swift:5.5
+          - swift:5.6
           - swiftlang/swift:nightly-main
         swiftos:
           - focal
@@ -27,26 +26,24 @@ jobs:
       - name: Install SQLite dependency
         run: apt-get -q update && apt-get -q install -y libsqlite3-dev
       - name: Check out package
-        uses: actions/checkout@v2
-      - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
+        uses: actions/checkout@v3
+      - name: Run tests
+        run: swift test
     
   macos-all:
     strategy:
       fail-fast: false
       matrix:
-        xcode:
-          - latest
-          - latest-stable
-    runs-on: macos-11
+        macos: ['macos-11', 'macos-12']
+        xcode: ['latest-stable', 'latest']
+        exclude: [{ macos: 'macos-11', xcode: 'latest' }]
+    runs-on: ${{ matrix.macos }}
     steps:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with: 
           xcode-version: ${{ matrix.xcode }}
       - name: Check out package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run tests with Thread Sanitizer
-        run: |
-          swift test --sanitize=thread -Xlinker -rpath \
-                -Xlinker $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx
+        run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "FluentSQLiteDriver", targets: ["FluentSQLiteDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("composite-primary-key-models")),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.27.0"),
         .package(url: "https://github.com/vapor/sqlite-kit.git", from: "4.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "FluentSQLiteDriver", targets: ["FluentSQLiteDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("composite-primary-key-models")),
         .package(url: "https://github.com/vapor/sqlite-kit.git", from: "4.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/Sources/FluentSQLiteDriver/FluentSQLiteDatabase.swift
+++ b/Sources/FluentSQLiteDriver/FluentSQLiteDatabase.swift
@@ -28,7 +28,7 @@ extension _FluentSQLiteDatabase: Database {
                 }
                 .flatMap {
                     switch query.action {
-                    case .create:
+                    case .create where query.customIDKey != .string(""):
                         return connection.lastAutoincrementID().map {
                             let row = LastInsertRow(
                                 lastAutoincrementID: $0,

--- a/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
+++ b/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
@@ -12,6 +12,7 @@ final class FluentSQLiteDriverTests: XCTestCase {
     func testChildren() throws { try self.benchmarker.testChildren() }
     func testCodable() throws { try self.benchmarker.testCodable() }
     func testChunk() throws { try self.benchmarker.testChunk() }
+    func testCompositeID() throws { try self.benchmarker.testCompositeID() }
     func testCRUD() throws { try self.benchmarker.testCRUD() }
     func testEagerLoad() throws { try self.benchmarker.testEagerLoad() }
     func testEnum() throws { try self.benchmarker.testEnum() }


### PR DESCRIPTION
Treat it as meaning not to retrieve an inserted ID value. This is in support of upcoming FluentKit feature work.