### PR TITLE
Drop support for Swift 5.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,49 +1,96 @@
 name: test
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  pull_request: { branches: ['*'] }
+  push: { branches: [ main ] }
+
 env:
   LOG_LEVEL: debug
   SWIFT_DETERMINISTIC_HASHING: 1
 
 jobs:
-  linux-all:
-    strategy:
-      fail-fast: false
-      matrix:
-        swiftver:
-          - swift:5.4
-          - swift:5.5
-          - swift:5.6
-          - swiftlang/swift:nightly-main
-        swiftos:
-          - focal
-    container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
+
+  codecov:
     runs-on: ubuntu-latest
+    container: swift:5.7-jammy
     steps:
-      - name: Install SQLite dependency
+      # N.B.: When we switch to embedded SQLite, these first two steps should be removed,
+      # and the version saved to the environment should come from the checked-out package.
+      - name: Install libsqlite3 dependency
+        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
+      - name: Save SQLite version to env
+        run: |
+          echo SQLITE_VERSION="$(pkg-config --modversion sqlite3)" >> $GITHUB_ENV
+      - name: Check out package
+        uses: actions/checkout@v3
+      - name: Run local tests with coverage
+        run: swift test --enable-code-coverage
+      - name: Submit coverage report to Codecov.io
+        uses: vapor/swift-codecov-action@v0.2
+        with:
+          cc_flags: 'unittests'
+          cc_env_vars: 'SWIFT_VERSION,SWIFT_PLATFORM,RUNNER_OS,RUNNER_ARCH,SQLITE_VERSION'
+          cc_fail_ci_if_error: true
+          cc_verbose: true
+          cc_dry_run: false
+
+  # Check for API breakage versus main
+  api-breakage:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    container: swift:5.7-jammy
+    steps:
+      - name: Install libsqlite3 dependency
         run: apt-get -q update && apt-get -q install -y libsqlite3-dev
       - name: Check out package
         uses: actions/checkout@v3
-      - name: Run tests
-        run: swift test
-    
-  macos-all:
+        with:
+          fetch-depth: 0
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the workspace as safe
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Check for API breaking changes
+        run: swift package diagnose-api-breaking-changes origin/main
+
+  # Run unit tests (Linux)
+  linux-unit:
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
-        macos: ['macos-11', 'macos-12']
-        xcode: ['latest-stable', 'latest']
-        exclude: [{ macos: 'macos-11', xcode: 'latest' }]
+        runner:
+          - swift:5.5-bionic
+          - swift:5.6-focal
+          - swift:5.7-jammy
+          - swiftlang/swift:nightly-main-jammy
+    container: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install libsqlite3 dependency
+        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Run tests with Thread Sanitizer
+        run: swift test --sanitize=thread
+
+
+  # Run unit tests (macOS).
+  macos-unit:
+    if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        macos:
+          - macos-11
+          - macos-12
+        xcode:
+          - latest-stable
     runs-on: ${{ matrix.macos }}
     steps:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with: 
           xcode-version: ${{ matrix.xcode }}
-      - name: Check out package
+      - name: Check out code
         uses: actions/checkout@v3
       - name: Run tests with Thread Sanitizer
-        run: swift test
+        run: swift test --sanitize=thread

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
Minimum supported version is now Swift 5.5.

Also includes the same upgrades to CI as those found in vapor/sqlite-kit#100 (most notably, adding the API breakage check and code coverage).