### PR TITLE
Add experimental support for watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,8 @@ let package = Package(
     name: "fluent-sqlite-driver",
     platforms: [
         .macOS(.v10_15),
-        .iOS(.v13)
+        .iOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
         .library(name: "FluentSQLiteDriver", targets: ["FluentSQLiteDriver"]),


### PR DESCRIPTION
Adds watchOS adds a target platform to enable it to be built for that platform.

**Note:** watchOS support is very much experimental and not currently a supported platform, though there is no reason why it shouldn't work