### PR TITLE
Update for the nested subpath changes in FluentKit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+*                            @gwynne
+/.github/CONTRIBUTING.md     @gwynne @0xTim
+/.github/workflows/*.yml     @gwynne @0xTim
+/.github/workflows/test.yml  @gwynne
+/.spi.yml                    @gwynne @0xTim
+/.gitignore                  @gwynne @0xTim
+/LICENSE                     @gwynne @0xTim
+/README.md                   @gwynne @0xTim

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to Fluent's SQLite Driver
+
+👋 Welcome to the Vapor team! 
+
+## Xcode
+
+To open the project in Xcode:
+
+- Clone the repo to your computer
+- Drag and drop the folder onto Xcode
+
+To test within Xcode, press `CMD+U`.
+
+## SPM
+
+To develop using SPM, open the code in your favorite code editor. Use the following commands from within the project's root folder to build and test.
+
+```sh
+swift build
+swift test
+```
+
+## SemVer
+
+Vapor follows [SemVer](https://semver.org). This means that any changes to the source code that can cause
+existing code to stop compiling _must_ wait until the next major version to be included. 
+
+Code that is only additive and will not break any existing code can be included in the next minor release.
+
+----------
+
+Join us on Discord if you have any questions: [vapor.team](http://vapor.team).
+
+&mdash; Thanks! 🙌

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: test
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
-  pull_request: { branches: ['*'] }
+  pull_request: { types: [opened, reopened, synchronize, ready_for_review] }
   push: { branches: [ main ] }
 
 jobs:

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,9 @@ let package = Package(
         .library(name: "FluentSQLiteDriver", targets: ["FluentSQLiteDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.27.0"),
-        .package(url: "https://github.com/vapor/sqlite-kit.git", from: "4.0.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.43.0"),
+        .package(url: "https://github.com/vapor/sqlite-kit.git", from: "4.3.1"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2"),
     ],
     targets: [
         .target(name: "FluentSQLiteDriver", dependencies: [

--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@
     <a href="LICENSE">
         <img src="http://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License">
     </a>
-    <a href="https://github.com/vapor/fluent-sqlite-driver/actions">
-        <img src="https://github.com/vapor/fluent-sqlite-driver/workflows/test/badge.svg" alt="Continuous Integration">
+    <a href="https://github.com/vapor/fluent-sqlite-driver/actions/workflows/test.yml">
+        <img src="https://github.com/vapor/fluent-sqlite-driver/actions/workflows/test.yml/badge.svg?event=push" alt="Continuous Integration">
+    </a>
+    <a href="https://codecov.io/gh/vapor/fluent-sqlite-driver">
+        <img src="https://codecov.io/gh/vapor/fluent-sqlite-driver/branch/main/graph/badge.svg?token=srIFeETGfJ" alt="Test Coverage">
     </a>
     <a href="https://swift.org">
-        <img src="http://img.shields.io/badge/swift-5.2-brightgreen.svg" alt="Swift 5.2">
+        <img src="http://img.shields.io/badge/swift-5.6-brightgreen.svg" alt="Swift 5.6">
     </a>
 </p>

--- a/Sources/FluentSQLiteDriver/SQLiteConverterDelegate.swift
+++ b/Sources/FluentSQLiteDriver/SQLiteConverterDelegate.swift
@@ -16,9 +16,4 @@ struct SQLiteConverterDelegate: SQLConverterDelegate {
         default: return nil
         }
     }
-
-    func nestedFieldExpression(_ column: String, _ path: [String]) -> SQLExpression {
-        let path = path.joined(separator: ".")
-         return SQLRaw("JSON_EXTRACT(\(column), '$.\(path)')")
-    }
 }


### PR DESCRIPTION
vapor/fluent-kit#572 takes advantage of the new support added to SQLKit in vapor/sql-kit#169, so remove the obsolete legacy support here. 

Also does some minor tidying.

(Note: Since we now depend on a version of FluentKit that is multiple minor versions newer than before, this must also be semver-minor.)