### PR TITLE
Allow using DatabaseSchema.deleteField(_:)` with SQLite

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "FluentSQLiteDriver", targets: ["FluentSQLiteDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.3"),
-        .package(url: "https://github.com/vapor/sqlite-kit.git", from: "4.5.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
+        .package(url: "https://github.com/vapor/sqlite-kit.git", from: "4.5.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
     ],
     targets: [

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "FluentSQLiteDriver", targets: ["FluentSQLiteDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.3"),
-        .package(url: "https://github.com/vapor/sqlite-kit.git", from: "4.5.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
+        .package(url: "https://github.com/vapor/sqlite-kit.git", from: "4.5.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
     ],
     targets: [

--- a/Sources/FluentSQLiteDriver/FluentSQLiteConfiguration.swift
+++ b/Sources/FluentSQLiteDriver/FluentSQLiteConfiguration.swift
@@ -59,8 +59,8 @@ extension DatabaseConfigurationFactory {
     /// - Parameters:
     ///   - configuration: The underlying `SQLiteConfiguration`.
     ///   - maxConnnectionsPerEventLoop: Ignored. The value is always treated as 1.
-    ///   - dataEncoder: An ``SQLiteDataEncoder`` used to translate bound query parameters into `SQLiteData` values.
-    ///   - dataDecoder: An ``SQLiteDataDecoder`` used to translate `SQLiteData` values into output values.
+    ///   - dataEncoder: An `SQLiteDataEncoder` used to translate bound query parameters into `SQLiteData` values.
+    ///   - dataDecoder: An `SQLiteDataDecoder` used to translate `SQLiteData` values into output values.
     ///   - queryLogLevel: The level at which SQL queries issued through the Fluent or SQLKit interfaces will be logged.
     /// - Returns: A configuration factory,
     public static func sqlite(

--- a/Sources/FluentSQLiteDriver/FluentSQLiteDatabase.swift
+++ b/Sources/FluentSQLiteDriver/FluentSQLiteDatabase.swift
@@ -48,12 +48,10 @@ struct FluentSQLiteDatabase: Database, SQLDatabase, SQLiteDatabase {
                 case .dataType(_, .enum(_)): return false
                 default: return true
             } }
-            guard schema.createConstraints.isEmpty, schema.updateFields.isEmpty,
-                  schema.deleteFields.isEmpty, schema.deleteConstraints.isEmpty
-            else {
+            guard schema.createConstraints.isEmpty, schema.updateFields.isEmpty, schema.deleteConstraints.isEmpty else {
                 return self.eventLoop.makeFailedFuture(FluentSQLiteUnsupportedAlter())
             }
-            if schema.createFields.isEmpty { // If there were only enum updates, bail out.
+            if schema.createFields.isEmpty, schema.deleteFields.isEmpty { // If there were only enum updates, bail out.
                 return self.eventLoop.makeSucceededFuture(())
             }
         }


### PR DESCRIPTION
SQLite has supported `ALTER TABLE ... DROP COLUMN ...` since SQLite 3.35.0, so Fluent no longer needs to restrict this functionality. Fixes #91 - thanks to @wojexe for reporting!

Also fixes a DocC warning and updates dependency requirements.