### PR TITLE
Shut down the driver's connection pool safely

### DIFF
--- a/Sources/FluentSQLiteDriver/FluentSQLiteDriver.swift
+++ b/Sources/FluentSQLiteDriver/FluentSQLiteDriver.swift
@@ -27,7 +27,7 @@ struct FluentSQLiteDriver: DatabaseDriver {
     }
 
     func shutdown() {
-        self.pool.shutdown()
+        try? self.pool.syncShutdownGracefully()
     }
 }
 


### PR DESCRIPTION
Specifically, don't use the soft-deprecated AsyncKit API that calls `EventLoopFuture.wait()` internally; use the one that at least does it with Dispatch (best we can do without changing Fluent's driver interface).