### PR TITLE
Fixes typo in `FluentSQLiteConfiguration.swift`

### DIFF
--- a/Sources/FluentSQLiteDriver/FluentSQLiteConfiguration.swift
+++ b/Sources/FluentSQLiteDriver/FluentSQLiteConfiguration.swift
@@ -58,7 +58,7 @@ extension DatabaseConfigurationFactory {
     ///
     /// - Parameters:
     ///   - configuration: The underlying `SQLiteConfiguration`.
-    ///   - maxConnnectionsPerEventLoop: Ignored. The value is always treated as 1.
+    ///   - maxConnectionsPerEventLoop: Ignored. The value is always treated as 1.
     ///   - dataEncoder: An `SQLiteDataEncoder` used to translate bound query parameters into `SQLiteData` values.
     ///   - dataDecoder: An `SQLiteDataDecoder` used to translate `SQLiteData` values into output values.
     ///   - queryLogLevel: The level at which SQL queries issued through the Fluent or SQLKit interfaces will be logged.


### PR DESCRIPTION
Fixes typo in `FluentSQLiteConfiguration.swift`.

I hate to be this person but my editor was yelling at me, so I decided to be the change that I want to see in the world. 

![image](https://github.com/user-attachments/assets/74099f66-d9f2-474b-8aba-30558b61b0cd)
