### PR TITLE
Some minor cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.swift]
+indent_style = space
+indent_size = 4
+tab_width = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,3 +10,5 @@ jobs:
   unit-tests:
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
     secrets: inherit
+    with:
+      with_android: true

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,77 @@
+{
+  "fileScopedDeclarationPrivacy" : {
+    "accessLevel" : "private"
+  },
+  "indentConditionalCompilationBlocks" : false,
+  "indentSwitchCaseLabels" : false,
+  "indentation" : {
+    "spaces" : 4
+  },
+  "lineBreakAroundMultilineExpressionChainComponents" : false,
+  "lineBreakBeforeControlFlowKeywords" : false,
+  "lineBreakBeforeEachArgument" : false,
+  "lineBreakBeforeEachGenericRequirement" : false,
+  "lineBreakBetweenDeclarationAttributes" : false,
+  "lineLength" : 150,
+  "maximumBlankLines" : 1,
+  "multiElementCollectionTrailingCommas" : true,
+  "noAssignmentInExpressions" : {
+    "allowedFunctions" : [
+    ]
+  },
+  "prioritizeKeepingFunctionOutputTogether" : false,
+  "reflowMultilineStringLiterals" : {
+    "never" : {
+    }
+  },
+  "respectsExistingLineBreaks" : true,
+  "rules" : {
+    "AllPublicDeclarationsHaveDocumentation" : false,
+    "AlwaysUseLiteralForEmptyCollectionInit" : true,
+    "AlwaysUseLowerCamelCase" : true,
+    "AmbiguousTrailingClosureOverload" : true,
+    "AvoidRetroactiveConformances" : true,
+    "BeginDocumentationCommentWithOneLineSummary" : false,
+    "DoNotUseSemicolons" : true,
+    "DontRepeatTypeInStaticProperties" : true,
+    "FileScopedDeclarationPrivacy" : true,
+    "FullyIndirectEnum" : true,
+    "GroupNumericLiterals" : true,
+    "IdentifiersMustBeASCII" : true,
+    "NeverForceUnwrap" : false,
+    "NeverUseForceTry" : false,
+    "NeverUseImplicitlyUnwrappedOptionals" : false,
+    "NoAccessLevelOnExtensionDeclaration" : true,
+    "NoAssignmentInExpressions" : true,
+    "NoBlockComments" : true,
+    "NoCasesWithOnlyFallthrough" : true,
+    "NoEmptyLinesOpeningClosingBraces" : false,
+    "NoEmptyTrailingClosureParentheses" : true,
+    "NoLabelsInCasePatterns" : true,
+    "NoLeadingUnderscores" : false,
+    "NoParensAroundConditions" : true,
+    "NoPlaygroundLiterals" : true,
+    "NoVoidReturnOnFunctionSignature" : true,
+    "OmitExplicitReturns" : false,
+    "OneCasePerLine" : true,
+    "OneVariableDeclarationPerLine" : true,
+    "OnlyOneTrailingClosureArgument" : true,
+    "OrderedImports" : true,
+    "ReplaceForEachWithForLoop" : true,
+    "ReturnVoidInsteadOfEmptyTuple" : true,
+    "TypeNamesShouldBeCapitalized" : true,
+    "UseEarlyExits" : true,
+    "UseExplicitNilCheckInConditions" : true,
+    "UseLetInEveryBoundCaseVariable" : true,
+    "UseShorthandTypeNames" : true,
+    "UseSingleLinePropertyGetter" : true,
+    "UseSynthesizedInitializer" : true,
+    "UseTripleSlashForDocumentationComments" : true,
+    "UseWhereClausesInForLoops" : false,
+    "ValidateDocumentationComments" : false
+  },
+  "spacesAroundRangeFormationOperators" : true,
+  "spacesBeforeEndOfLineComments" : 1,
+  "tabWidth" : 4,
+  "version" : 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 import PackageDescription
 
 let package = Package(
@@ -13,9 +13,9 @@ let package = Package(
         .library(name: "FluentSQLiteDriver", targets: ["FluentSQLiteDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.49.0"),
-        .package(url: "https://github.com/vapor/sqlite-kit.git", from: "4.5.1"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.51.0"),
+        .package(url: "https://github.com/vapor/sqlite-kit.git", from: "4.5.2"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.3"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 <p align="center">
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/vapor/fluent-sqlite-driver/assets/1130717/8ea4e505-ae30-4f94-982c-39c86c01754f">
-  <source media="(prefers-color-scheme: light)" srcset="https://github.com/vapor/fluent-sqlite-driver/assets/1130717/9553b52f-7724-4d75-8a8b-5be564cd20d8">
-  <img src="https://github.com/vapor/fluent-sqlite-driver/assets/1130717/9553b52f-7724-4d75-8a8b-5be564cd20d8" height="96" alt="FluentSQLiteDriver">
-</picture> 
+<img src="https://design.vapor.codes/images/vapor-fluentsqlitedriver.svg" height="96" alt="FluentSQLiteDriver">
 <br>
 <br>
 <a href="https://docs.vapor.codes/4.0/"><img src="https://design.vapor.codes/images/readthedocs.svg" alt="Documentation"></a>
@@ -11,7 +7,7 @@
 <a href="LICENSE"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
 <a href="https://github.com/vapor/fluent-sqlite-driver/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/fluent-sqlite-driver/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="Continuous Integration"></a>
 <a href="https://codecov.io/github/vapor/fluent-sqlite-driver"><img src="https://img.shields.io/codecov/c/github/vapor/fluent-sqlite-driver?style=plastic&logo=codecov&label=codecov"></a>
-<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift58up.svg" alt="Swift 5.8+"></a>
+<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift510up.svg" alt="Swift 5.10+"></a>
 </p>
 
 <br>

--- a/Sources/FluentSQLiteDriver/Docs.docc/theme-settings.json
+++ b/Sources/FluentSQLiteDriver/Docs.docc/theme-settings.json
@@ -8,11 +8,14 @@
       "fluentsqlitedriver": "hsl(215, 45%, 58%)",
       "documentation-intro-fill": "radial-gradient(circle at top, var(--color-fluentsqlitedriver) 30%, #000 100%)",
       "documentation-intro-accent": "var(--color-fluentsqlitedriver)",
+      "documentation-intro-eyebrow": "white",
+      "documentation-intro-figure": "white",
+      "documentation-intro-title": "white",
       "logo-base":  { "dark": "#fff", "light": "#000" },
       "logo-shape": { "dark": "#000", "light": "#fff" },
       "fill":       { "dark": "#000", "light": "#fff" }
     },
-    "icons": { "technology": "/fluentsqlitedriver/images/vapor-fluentsqlitedriver-logo.svg" }
+    "icons": { "technology": "/fluentsqlitedriver/images/FluentSQLiteDriver/vapor-fluentsqlitedriver-logo.svg" }
   },
   "features": {
     "quickNavigation": { "enable": true },

--- a/Sources/FluentSQLiteDriver/FluentSQLiteConfiguration.swift
+++ b/Sources/FluentSQLiteDriver/FluentSQLiteConfiguration.swift
@@ -1,8 +1,8 @@
-import NIO
-import FluentKit
-import SQLiteKit
 import AsyncKit
+import FluentKit
 import Logging
+import NIO
+import SQLiteKit
 
 // Hint: Yes, I know what default arguments are. This ridiculous spelling out of each alternative avoids public API
 // breakage from adding the defaults. And yes, `maxConnectionsPerEventLoop` is not forwarded on purpose, it's not
@@ -11,18 +11,22 @@ import Logging
 
 extension DatabaseConfigurationFactory {
     /// Shorthand for ``sqlite(_:maxConnectionsPerEventLoop:connectionPoolTimeout:dataEncoder:dataDecoder:sqlLogLevel:)``.
-    public static func sqlite(_ config: SQLiteConfiguration = .memory, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10)) -> Self {
+    public static func sqlite(
+        _ config: SQLiteConfiguration = .memory, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10)
+    ) -> Self {
         self.sqlite(config, connectionPoolTimeout: connectionPoolTimeout, dataEncoder: .init(), dataDecoder: .init(), sqlLogLevel: .debug)
     }
     /// Shorthand for ``sqlite(_:maxConnectionsPerEventLoop:connectionPoolTimeout:dataEncoder:dataDecoder:sqlLogLevel:)``.
     public static func sqlite(
-        _ config: SQLiteConfiguration = .memory, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10), dataEncoder: SQLiteDataEncoder
+        _ config: SQLiteConfiguration = .memory, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        dataEncoder: SQLiteDataEncoder
     ) -> Self {
         self.sqlite(config, connectionPoolTimeout: connectionPoolTimeout, dataEncoder: dataEncoder, dataDecoder: .init(), sqlLogLevel: .debug)
     }
     /// Shorthand for ``sqlite(_:maxConnectionsPerEventLoop:connectionPoolTimeout:dataEncoder:dataDecoder:sqlLogLevel:)``.
     public static func sqlite(
-        _ config: SQLiteConfiguration = .memory, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10), dataDecoder: SQLiteDataDecoder
+        _ config: SQLiteConfiguration = .memory, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        dataDecoder: SQLiteDataDecoder
     ) -> Self {
         self.sqlite(config, connectionPoolTimeout: connectionPoolTimeout, dataEncoder: .init(), dataDecoder: dataDecoder, sqlLogLevel: .debug)
     }
@@ -35,7 +39,8 @@ extension DatabaseConfigurationFactory {
     }
     /// Shorthand for ``sqlite(_:maxConnectionsPerEventLoop:connectionPoolTimeout:dataEncoder:dataDecoder:sqlLogLevel:)``.
     public static func sqlite(
-        _ config: SQLiteConfiguration = .memory, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10), sqlLogLevel: Logger.Level?
+        _ config: SQLiteConfiguration = .memory, maxConnectionsPerEventLoop: Int = 1, connectionPoolTimeout: TimeAmount = .seconds(10),
+        sqlLogLevel: Logger.Level?
     ) -> Self {
         self.sqlite(config, connectionPoolTimeout: connectionPoolTimeout, dataEncoder: .init(), dataDecoder: .init(), sqlLogLevel: sqlLogLevel)
     }

--- a/Sources/FluentSQLiteDriver/FluentSQLiteDatabase.swift
+++ b/Sources/FluentSQLiteDriver/FluentSQLiteDatabase.swift
@@ -1,9 +1,9 @@
-import FluentSQL
-import SQLiteKit
-import NIOCore
-import SQLiteNIO
-import SQLKit
 import FluentKit
+import FluentSQL
+import NIOCore
+import SQLKit
+import SQLiteKit
+import SQLiteNIO
 
 struct FluentSQLiteDatabase: Database, SQLDatabase, SQLiteDatabase {
     let database: any SQLiteDatabase
@@ -12,28 +12,27 @@ struct FluentSQLiteDatabase: Database, SQLDatabase, SQLiteDatabase {
     let dataDecoder: SQLiteDataDecoder
     let queryLogLevel: Logger.Level?
     let inTransaction: Bool
-    
+
     private func adjustFluentQuery(_ original: DatabaseQuery, _ converted: any SQLExpression) -> any SQLExpression {
         /// For `.create` query actions, we want to return the generated IDs, unless the `customIDKey` is the
         /// empty string, which we use as a very hacky signal for "we don't implement this for composite IDs yet".
-        if case .create = original.action, original.customIDKey != .some(.string("")) {
-            return SQLKit.SQLList([converted, SQLReturning(.init((original.customIDKey ?? .id).description))], separator: SQLRaw(" "))
-        } else {
+        guard case .create = original.action, original.customIDKey != .some(.string("")) else {
             return converted
         }
+        return SQLKit.SQLList([converted, SQLReturning(.init((original.customIDKey ?? .id).description))], separator: SQLRaw(" "))
     }
-    
+
     // Database
-    
-    func execute(query: DatabaseQuery, onOutput: @escaping @Sendable (any DatabaseOutput) -> ()) -> EventLoopFuture<Void> {
+
+    func execute(query: DatabaseQuery, onOutput: @escaping @Sendable (any DatabaseOutput) -> Void) -> EventLoopFuture<Void> {
         /// SQLiteKit will handle applying the configured data decoder to each row when providing `SQLRow`s.
-        return self.execute(
+        self.execute(
             sql: self.adjustFluentQuery(query, SQLQueryConverter(delegate: SQLiteConverterDelegate()).convert(query)),
             { onOutput($0.databaseOutput()) }
         )
     }
-    
-    func execute(query: DatabaseQuery, onOutput: @escaping @Sendable (any DatabaseOutput) -> ()) async throws {
+
+    func execute(query: DatabaseQuery, onOutput: @escaping @Sendable (any DatabaseOutput) -> Void) async throws {
         try await self.execute(
             sql: self.adjustFluentQuery(query, SQLQueryConverter(delegate: SQLiteConverterDelegate()).convert(query)),
             { onOutput($0.databaseOutput()) }
@@ -42,12 +41,14 @@ struct FluentSQLiteDatabase: Database, SQLDatabase, SQLiteDatabase {
 
     func execute(schema: DatabaseSchema) -> EventLoopFuture<Void> {
         var schema = schema
-        
+
         if schema.action == .update {
-            schema.updateFields = schema.updateFields.filter { switch $0 { // Filter out enum updates.
-                case .dataType(_, .enum(_)): return false
-                default: return true
-            } }
+            schema.updateFields = schema.updateFields.filter {
+                switch $0 { // Filter out enum updates.
+                case .dataType(_, .enum(_)): false
+                default: true
+                }
+            }
             guard schema.createConstraints.isEmpty, schema.updateFields.isEmpty, schema.deleteConstraints.isEmpty else {
                 return self.eventLoop.makeFailedFuture(FluentSQLiteUnsupportedAlter())
             }
@@ -55,7 +56,7 @@ struct FluentSQLiteDatabase: Database, SQLDatabase, SQLiteDatabase {
                 return self.eventLoop.makeSucceededFuture(())
             }
         }
-        
+
         return self.execute(
             sql: SQLSchemaConverter(delegate: SQLiteConverterDelegate()).convert(schema),
             { self.logger.debug("Unexpected row returned from schema query: \($0)") }
@@ -65,30 +66,29 @@ struct FluentSQLiteDatabase: Database, SQLDatabase, SQLiteDatabase {
     func execute(enum: DatabaseEnum) -> EventLoopFuture<Void> {
         self.eventLoop.makeSucceededFuture(())
     }
-    
+
     func withConnection<T>(_ closure: @escaping @Sendable (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
         self.eventLoop.makeFutureWithTask { try await self.withConnection { try await closure($0).get() } }
     }
-    
+
     func withConnection<T>(_ closure: @escaping @Sendable (any Database) async throws -> T) async throws -> T {
         try await self.withConnection {
-            try await closure(FluentSQLiteDatabase(
-                database: $0,
-                context: self.context,
-                dataEncoder: self.dataEncoder,
-                dataDecoder: self.dataDecoder,
-                queryLogLevel: self.queryLogLevel,
-                inTransaction: self.inTransaction
-            ))
+            try await closure(
+                FluentSQLiteDatabase(
+                    database: $0,
+                    context: self.context,
+                    dataEncoder: self.dataEncoder,
+                    dataDecoder: self.dataDecoder,
+                    queryLogLevel: self.queryLogLevel,
+                    inTransaction: self.inTransaction
+                ))
         }
     }
-    
+
     func transaction<T>(_ closure: @escaping @Sendable (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
-        self.inTransaction ?
-            closure(self)  :
-            self.eventLoop.makeFutureWithTask { try await self.transaction { try await closure($0).get() } }
+        self.inTransaction ? closure(self) : self.eventLoop.makeFutureWithTask { try await self.transaction { try await closure($0).get() } }
     }
-    
+
     func transaction<T>(_ closure: @escaping @Sendable (any Database) async throws -> T) async throws -> T {
         guard !self.inTransaction else {
             return try await closure(self)
@@ -103,11 +103,11 @@ struct FluentSQLiteDatabase: Database, SQLDatabase, SQLiteDatabase {
                 queryLogLevel: self.queryLogLevel,
                 inTransaction: true
             )
-            
+
             try await db.raw("BEGIN TRANSACTION").run()
             do {
                 let result = try await closure(db)
-                
+
                 try await db.raw("COMMIT TRANSACTION").run()
                 return result
             } catch {
@@ -116,31 +116,32 @@ struct FluentSQLiteDatabase: Database, SQLDatabase, SQLiteDatabase {
             }
         }
     }
-    
+
     // SQLDatabase
 
     var dialect: any SQLDialect {
         self.database.sql(encoder: self.dataEncoder, decoder: self.dataDecoder, queryLogLevel: self.queryLogLevel).dialect
     }
-    
+
     var version: (any SQLDatabaseReportedVersion)? {
         self.database.sql(encoder: self.dataEncoder, decoder: self.dataDecoder, queryLogLevel: self.queryLogLevel).version
     }
-    
-    func execute(sql query: any SQLExpression, _ onRow: @escaping @Sendable (any SQLRow) -> ()) -> EventLoopFuture<Void> {
+
+    func execute(sql query: any SQLExpression, _ onRow: @escaping @Sendable (any SQLRow) -> Void) -> EventLoopFuture<Void> {
         self.database.sql(encoder: self.dataEncoder, decoder: self.dataDecoder, queryLogLevel: self.queryLogLevel).execute(sql: query, onRow)
     }
-    
-    func execute(sql query: any SQLExpression, _ onRow: @escaping @Sendable (any SQLRow) -> ()) async throws {
-        try await self.database.sql(encoder: self.dataEncoder, decoder: self.dataDecoder, queryLogLevel: self.queryLogLevel).execute(sql: query, onRow)
+
+    func execute(sql query: any SQLExpression, _ onRow: @escaping @Sendable (any SQLRow) -> Void) async throws {
+        try await self.database.sql(encoder: self.dataEncoder, decoder: self.dataDecoder, queryLogLevel: self.queryLogLevel).execute(
+            sql: query, onRow)
     }
-    
+
     func withSession<R>(_ closure: @escaping @Sendable (any SQLDatabase) async throws -> R) async throws -> R {
         try await self.database.sql(encoder: self.dataEncoder, decoder: self.dataDecoder, queryLogLevel: self.queryLogLevel).withSession(closure)
     }
 
     // SQLiteDatabase
-    
+
     func query(_ query: String, _ binds: [SQLiteData], logger: Logger, _ onRow: @escaping @Sendable (SQLiteRow) -> Void) -> EventLoopFuture<Void> {
         self.withConnection { $0.query(query, binds, logger: logger, onRow) }
     }

--- a/Sources/FluentSQLiteDriver/FluentSQLiteDriver.swift
+++ b/Sources/FluentSQLiteDriver/FluentSQLiteDriver.swift
@@ -1,9 +1,9 @@
-import NIOCore
-import FluentKit
 @preconcurrency import AsyncKit
-import SQLiteNIO
-import SQLiteKit
+import FluentKit
 import Logging
+import NIOCore
+import SQLiteKit
+import SQLiteNIO
 
 struct FluentSQLiteDriver: DatabaseDriver {
     let pool: EventLoopGroupConnectionPool<SQLiteConnectionSource>
@@ -29,7 +29,7 @@ struct FluentSQLiteDriver: DatabaseDriver {
     func shutdown() {
         try? self.pool.syncShutdownGracefully()
     }
-    
+
     func shutdownAsync() async {
         try? await self.pool.shutdownAsync()
     }

--- a/Sources/FluentSQLiteDriver/SQLiteConverterDelegate.swift
+++ b/Sources/FluentSQLiteDriver/SQLiteConverterDelegate.swift
@@ -1,20 +1,20 @@
+import FluentKit
 import FluentSQL
 import SQLKit
-import FluentKit
 
 struct SQLiteConverterDelegate: SQLConverterDelegate {
     func customDataType(_ dataType: DatabaseSchema.DataType) -> (any SQLExpression)? {
         switch dataType {
         case .string:
-            return SQLRaw("TEXT")
+            SQLRaw("TEXT")
         case .datetime:
-            return SQLRaw("REAL")
+            SQLRaw("REAL")
         case .int64:
-            return SQLRaw("INTEGER")
+            SQLRaw("INTEGER")
         case .enum:
-            return SQLRaw("TEXT")
+            SQLRaw("TEXT")
         default:
-            return nil
+            nil
         }
     }
 }

--- a/Sources/FluentSQLiteDriver/SQLiteError+Database.swift
+++ b/Sources/FluentSQLiteDriver/SQLiteError+Database.swift
@@ -1,41 +1,41 @@
-import SQLiteNIO
 import FluentKit
+import SQLiteNIO
 
 // Required for Database Error
 extension SQLiteError {
     public var isSyntaxError: Bool {
         switch self.reason {
         case .error, .schema:
-            return true
+            true
         default:
-            return false
+            false
         }
     }
 
     public var isConnectionClosed: Bool {
         switch self.reason {
         case .misuse, .cantOpen:
-            return true
+            true
         default:
-            return false
+            false
         }
     }
 
     public var isConstraintFailure: Bool {
         switch self.reason {
         case .constraint, .constraintCheckFailed, .constraintUniqueFailed, .constraintTriggerFailed,
-             .constraintNotNullFailed, .constraintCommitHookFailed, .constraintForeignKeyFailed,
-             .constraintPrimaryKeyFailed, .constraintUserFunctionFailed, .constraintVirtualTableFailed,
-             .constraintUniqueRowIDFailed, .constraintStrictDataTypeFailed, .constraintUpdateTriggerDeletedRow:
-            return true
+            .constraintNotNullFailed, .constraintCommitHookFailed, .constraintForeignKeyFailed,
+            .constraintPrimaryKeyFailed, .constraintUserFunctionFailed, .constraintVirtualTableFailed,
+            .constraintUniqueRowIDFailed, .constraintStrictDataTypeFailed, .constraintUpdateTriggerDeletedRow:
+            true
         default:
-            return false
+            false
         }
     }
 }
 
 #if compiler(<6)
-extension SQLiteError: DatabaseError { }
+extension SQLiteError: DatabaseError {}
 #else
-extension SQLiteError: @retroactive DatabaseError { }
+extension SQLiteError: @retroactive DatabaseError {}
 #endif

--- a/Sources/FluentSQLiteDriver/SQLiteRow+Database.swift
+++ b/Sources/FluentSQLiteDriver/SQLiteRow+Database.swift
@@ -1,7 +1,7 @@
-import Foundation
-import SQLiteNIO
-import SQLiteKit
 import FluentKit
+import Foundation
+import SQLiteKit
+import SQLiteNIO
 
 extension SQLRow {
     /// Returns a `DatabaseOutput` for this row.
@@ -19,7 +19,7 @@ private struct SQLRowDatabaseOutput: DatabaseOutput {
 
     /// The most recently set schema value (see `DatabaseOutput.schema(_:)`).
     let schema: String?
-    
+
     // See `CustomStringConvertible.description`.
     var description: String {
         String(describing: self.row)
@@ -29,22 +29,22 @@ private struct SQLRowDatabaseOutput: DatabaseOutput {
     private func adjust(key: FieldKey) -> String {
         (self.schema.map { .prefix(.prefix(.string($0), "_"), key) } ?? key).description
     }
-    
+
     // See `DatabaseOutput.schema(_:)`.
     func schema(_ schema: String) -> any DatabaseOutput {
         SQLRowDatabaseOutput(row: self.row, schema: schema)
     }
-    
+
     // See `DatabaseOutput.contains(_:)`.
     func contains(_ key: FieldKey) -> Bool {
         self.row.contains(column: self.adjust(key: key))
     }
-    
+
     // See `DatabaseOutput.decodeNil(_:)`.
     func decodeNil(_ key: FieldKey) throws -> Bool {
         try self.row.decodeNil(column: self.adjust(key: key))
     }
-    
+
     // See `DatabaseOutput.decode(_:as:)`.
     func decode<T: Decodable>(_ key: FieldKey, as: T.Type) throws -> T {
         try self.row.decode(column: self.adjust(key: key), as: T.self)
@@ -61,17 +61,17 @@ extension SQLiteNIO.SQLiteRow: FluentKit.DatabaseOutput {
     public func schema(_ schema: String) -> any DatabaseOutput {
         self.databaseOutput().schema(schema)
     }
-    
+
     // See `DatabaseOutput.contains(_:)`.
     public func contains(_ key: FieldKey) -> Bool {
         self.databaseOutput().contains(key)
     }
-    
+
     // See `DatabaseOutput.decodeNil(_:)`.
     public func decodeNil(_ key: FieldKey) throws -> Bool {
         try self.databaseOutput().decodeNil(key)
     }
-    
+
     // See `DatabaseOutput.decode(_:as:)`.
     public func decode<T: Decodable>(_ key: FieldKey, as: T.Type) throws -> T {
         try self.databaseOutput().decode(key, as: T.self)

--- a/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
+++ b/Tests/FluentSQLiteDriverTests/FluentSQLiteDriverTests.swift
@@ -216,8 +216,8 @@ final class FluentSQLiteDriverTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         self.dbs = Databases(threadPool: NIOThreadPool.singleton, on: MultiThreadedEventLoopGroup.singleton)
-        self.dbs.use(.sqlite(.memory), as: .sqlite)
-        self.dbs.use(.sqlite(.file(self.benchmarkPath)), as: .init(string: "benchmark"))
+        self.dbs.use(.sqlite(.memory, connectionPoolTimeout: .seconds(30)), as: .sqlite)
+        self.dbs.use(.sqlite(.file(self.benchmarkPath), connectionPoolTimeout: .seconds(30)), as: .init(string: "benchmark"))
         self.database = self.dbs.database(.sqlite, logger: .init(label: "test.fluent.sqlite"), on: MultiThreadedEventLoopGroup.singleton.any())
     }
 


### PR DESCRIPTION
**These changes are now available in [4.8.1](https://github.com/vapor/fluent-sqlite-driver/releases/tag/4.8.1)**


Simple stuff, really - add a `.swift-format` and use it, bump the minimum Swift version to 5.10, update the CI and the README. you get the idea.